### PR TITLE
Tweak to console output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 db-version
 stats.db
 stats.db-journal
-password.py
+pool.cfg

--- a/bitHopper.py
+++ b/bitHopper.py
@@ -240,7 +240,8 @@ def bitHopper_Post(request):
         bithopper_global.log_msg('RPC request ' + str(data) + " submitted to " + str(pool_server['name']))
     else:
         if data == []:
-            rep = ""
+            """ If request contains no data, tell the user which remote procedure was called instead """
+            rep = rpc_request['method']
         else:
             rep = str(data[0][155:163])
         bithopper_global.log_msg('RPC request [' + rep + "] submitted to " + str(pool_server['name']))


### PR DESCRIPTION
At the moment, when remote procedure calls are made and the call carries no data (e.g. getwork requests), the console output looks like this:
# RPC request [] submitted to <server>

This change inserts the name of the RPC in these circumstances. The console output now looks like this:
# RPC request [getwork] submitted to <server>

RPCs that carry data (e.g. shares) still look like this:
# RPC request [5d417000] submitted to <server>

I find this clarifies the console display, since if you don't know that those blank-looking requests are getworks, they look like share submissions that are missing their payload!

I hearby release this tweak into the public domain (I think I'd have trouble asserting copyright over a one-line change anyway!)
