### PR TITLE
Patches to re_rateduration and bcpool fix

### DIFF
--- a/pool.py
+++ b/pool.py
@@ -329,25 +329,64 @@ class Pool():
         return -1
     
     def get_duration(self, server, response):
-        duration = -1
+        duration = -1 # I think this is not needed anymore? Could somebody double check?
         if 'api_key_duration_day_hour_min' in server:
             output = re.search(server['api_key_duration_day_hour_min'], response)
-            day = int(output.group(1).replace(' ', ''))
-            hour = int(output.group(2).replace(' ', ''))
-            minute = int(output.group(3).replace(' ', ''))
-            duration = day*24*3600 + hour * 3600 + minute * 60
+            try:
+                day = int(output.group(1).replace(' ', ''))
+            except AttributeError:
+                day = 0
+            try:
+                hour = int(output.group(2).replace(' ', ''))
+            except AttributeError:
+                hour = 0
+            try:
+                minute = int(output.group(3).replace(' ', ''))
+            except AttributeError:
+               minute = 0
+            if day == 0:
+                if hour == 0:
+                    if minute == 0:
+                        duration = -1
+                    else:
+                        duration = minute * 60
+                else:
+                    duration = hour * 3600 + minute * 60
+            else:
+                duration = day*24*3600 + hour * 3600 + minute * 60
         elif 'api_key_duration_hour_min' in server:
             output = re.search(server['api_key_duration_hour_min'], response)
-            hour = int(output.group(1).replace(' ', ''))
-            minute = int(output.group(2).replace(' ', ''))
-            duration = hour * 3600 + minute * 60
+            try:
+                hour = int(output.group(1).replace(' ', ''))
+            except AttributeError:
+                hour = 0
+            try:
+                minute = int(output.group(2).replace(' ', ''))
+            except AttributeError:
+                minute = 0
+            if hour == 0:
+                if minute == 0:
+                    duration = -1
+                else:
+                    duration = minute * 60
+            else:
+                duration = hour * 3600 + minute * 60
         elif 'api_key_duration_min' in server:
             output = re.search(server['api_key_duration_min'], response)
-            minute = int(output.group(1).replace(' ', ''))
-            duration = minute * 60
+            try:
+                minute = int(output.group(1).replace(' ', ''))
+            except AttributeError:
+                minute = 0
+            if minute == 0:
+                duration = -1
+            else:
+                duration = minute * 60
         elif 'api_key_duration_sec' in server:
             output = re.search(server['api_key_duration_sec'], response)
-            duration = int(output.group(1).replace(' ', ''))
+            try:
+                duration = int(output.group(1).replace(' ', ''))
+            except AttributeError:
+                duration = -1
         
         return duration
 

--- a/pools.cfg
+++ b/pools.cfg
@@ -240,12 +240,10 @@ url: http://mining.mainframe.nl
 [bcpool]
 name: BitcoinPool.com
 mine_address: bitcoinpool.com:8334 
-api_address: http://bitcoinpool.com/pooljson.php
-api_method: json
-api_key: round_shares
-api_key_ghashrate: hashrate
-api_key_duration: round_duration
-api_key_duration_day_hour_min: (\d+):(\d+):(\d+):
+api_address: http://bitcoinpool.com
+api_method: re_rateduration
+api_key_ghashrate: Pool Speed: <d class=\"info\">([\.0-9]+) Gh/s
+api_key_duration_day_hour_min: Round Duration: <d class=\"info\">(?:([0-9]+)d&nbsp;)?([0-9]+)h&nbsp;([0-9]+)m&nbsp;
 url: http://bitcoinpool.com
 
 [unitedminers]


### PR DESCRIPTION
Made re_rateduration not cause an exception when day, hour or min is missing from regexp match and instead it fails safely.

Also fixed bcpool by scraping from their index page using re_rateduration. Tested my patches and it appears to work just fine.
