### PR TITLE
changed irc server again

### DIFF
--- a/lpbot.py
+++ b/lpbot.py
@@ -33,7 +33,7 @@ class LpBot(SimpleIRCClient):
 	def _connect(self):
 		print "Connecting..."
 		try:
-			self.connect('irc.pedanticstoner.com', 6667, self.nick)
+			self.connect('irc.bithopper.org', 6667, self.nick)
 		except Exception, e:
 			print e
 


### PR DESCRIPTION
no rush on this one, but changed the irc server to irc.bithopper.org instead so it remains under your control instead of mine.  Right now it points to my irc server, but if something happens to it it will be trivial for you to move over to a different server without a code push.

all code public domain, though there is no code involved in this change, just the irc server
