### PR TITLE
Fixed bitminersunion.org stat for api use.  Partially fixed bitcoinpool.com

### DIFF
--- a/pools.cfg
+++ b/pools.cfg
@@ -251,7 +251,7 @@ mine_address: bitcoinpool.com:8334
 api_address: http://bitcoinpool.com
 api_method: re_rateduration
 api_key_ghashrate: Pool Speed: <d class=\"info\">([\.0-9]+) Gh/s
-api_key_duration_day_hour_min: Round Duration: <d class=\"info\">(?:([0-9]+)d&nbsp;)?([0-9]+)h&nbsp;([0-9]+)m&nbsp;
+api_key_duration_day_hour_min: <p class=\"title\"> Round Duration: <d class=\"info\">(?:([0-9]+)d&nbsp;)?([0-9]+)h&nbsp;([0-9]+)m&nbsp;
 url: http://bitcoinpool.com
 
 [unitedminers]

--- a/pools.cfg
+++ b/pools.cfg
@@ -266,10 +266,10 @@ url: http://www.unitedminers.com
 [bmunion]
 name: BitMinersUnion.org
 mine_address: pool.bitminersunion.org:8341
-api_address: http://www.bitminersunion.org/stats.php
+api_address: http://pool.bitminersunion.org/stats.php
 api_method: re
 api_key: Shares this round:([0-9]+)<br/>
-url: http://www.bitminersunion.org/
+url: http://pool.bitminersunion.org
 
 [btcpool24]
 name: BTCPool24


### PR DESCRIPTION
www.bitminersunion.org resides on 173.193.106.10. The stats are actually posted on an internal frame which is located on pool.binersunion.org (64.244.102.89).
