### PR TITLE
Yet again fixed user stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -344,10 +344,12 @@
 					var r = rows[i];
 					var row = items[r];
 
-					row_role = columns['Role String']['data'](payload, row, r);
-					if( !showDisabledPools && row_role == "disable" ){
-					    continue;		//Skip disabled pools
-					}
+                    if (id == "#table") {
+                        row_role = columns['Role String']['data'](payload, row, r);
+                        if( !showDisabledPools && row_role == "disable" ){
+                            continue; //Skip disabled pools
+                        }
+                    }
 
 					html += "<tr id=\"row_" + i + "\">";
 					


### PR DESCRIPTION
I see there is a new pull request from pueytan that also enables to hide info pools. Make sure that his addition also gets wrapped inside:

```
                if (id == "#table") { His additions }
```

Because otherwise worker stats won't appear anymore. Would this cause a conflict by the way?
