### PR TITLE
Fixed run-bithopper.bat

### DIFF
--- a/run-bithopper.bat
+++ b/run-bithopper.bat
@@ -1,3 +1,3 @@
 echo Going to %~dp0
 cd %~dp0
-python bitHopper.py --debug --scheduler OldDefaultScheduler --auth username,password 1> logfile.txt > 2> logfile-errors.txt
+python bitHopper.py --debug --scheduler OldDefaultScheduler 1> logfile.txt 2> logfile-errors.txt


### PR DESCRIPTION
Fixed typo and made default execution line better by removing --auth
