### PR TITLE
change headercontainer div height to shade background behind "show info" 

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
 			th.head {
 				border-bottom:2px solid white;
 			}
-			#headercontainer { position: fixed; top: 0; left: 0; right: 0; height: 85px; margin: 0; padding: 0; background-color: #272F87; }
+			#headercontainer { position: fixed; top: 0; left: 0; right: 0; height: 105px; margin: 0; padding: 0; background-color: #272F87; }
 
 			#round_duration {
 				color: White;


### PR DESCRIPTION
change headercontainer div height to shade background behind "show info" and "show disable" option boxes.
The change from 85 to 105 is released in the public domain.
