### PR TITLE
pools.cfg - new mining address for digbtc.net 

### DIFF
--- a/pools.cfg
+++ b/pools.cfg
@@ -301,7 +301,7 @@ url: http://pool.bloodys.com/?action=dashboard
 
 [digbtc]
 name: DigBTC.net
-mine_address: digbtc.net:8332
+mine_address: btc.digbtc.net:8332
 api_address: http://digbtc.net/papi.php
 api_method: json
 api_key: shares_this_round


### PR DESCRIPTION
From support@digbtc.net:

"Please use btc.digbtc.net to mining, which is stable, it is a mining server.
digbtc.net is our web server, sometimes it need mantaining, they are different servers."

All rights for this change transferred to c00w. 
