### PR TITLE
scpool for bitparking had incorrect url

### DIFF
--- a/pools.cfg
+++ b/pools.cfg
@@ -441,7 +441,7 @@ api_address: http://scpool.bitparking.com/user
 api_method: re
 api_key: Total Pool Shares</td><td>([0-9]+)
 api_strip: ' '
-url: http://bitparking.com/user/%(user)s
+url: http://scpool.bitparking.com/user/%(user)s
 
 [squid]
 name: SquidNet (scc)


### PR DESCRIPTION
Url was for namecoin and not solid coin pool
