### PR TITLE
very small pull request which reduces miner idles while writing to database

### DIFF
--- a/database.py
+++ b/database.py
@@ -98,7 +98,7 @@ class Database():
                         self.curs.execute(sql)
                     self.payout[server] = None
 
-                self.database.commit()
+            self.database.commit()
             eventlet.sleep(60)
 
     def check_database(self):


### PR DESCRIPTION
i had disabled database writes a while ago. yesterday i enabled them again and noticed a small lag while writing to database (hashrate in bithopper got from 1100mh down to 200mh [once] and (mostly) down to 800mh

i think its enough to lock only the acces to global vars. so i moved the database commit out of the lock range
