### PR TITLE
Typo in Payouts

### DIFF
--- a/plugins/payouts/payouts.py
+++ b/plugins/payouts/payouts.py
@@ -49,7 +49,7 @@ class Payouts():
                         getbalance = float(access.getreceivedbyaddress(wallet))
                         self.log_msg(server + ' ' + str(getbalance) + ' ' + wallet)
                         self.bitHopper.update_payout(server, float(getbalance))
-                    except Exception e:
+                    except Exception, e:
                         self.log_dbg("Error getting getreceivedbyaddress")
                         self.log_dbg(e)
 


### PR DESCRIPTION
error loading plugin: payouts invalid syntax line 52
