### PR TITLE
Removed "namecoin: Yep" from Masterpool config due to merged mining

### DIFF
--- a/pools.cfg
+++ b/pools.cfg
@@ -408,7 +408,6 @@ url: http://bitfarms.ca/
 
 [masterpool]
 name: MasterPool.eu (BTC+NMC)
-namecoin: Yep
 mine_address: US01.masterpool.eu:8888
 api_address: https://masterpool.eu/jsonstats
 api_method:json


### PR DESCRIPTION
Was causing an API error.
