### PR TITLE
New option in bh.cfg and updates on some pools

### DIFF
--- a/POOLS_INFO
+++ b/POOLS_INFO
@@ -291,7 +291,7 @@ info_1: Payouts are automatic and no need to signup - 8.35 Ghash/s @ 08.23.11
 info_1: Nmc pool (mine_nmc) - 47 Mhash/s @ 08.23.11
 info_2: Production at this pool stopped until merged mining @ block 19200
 info_3: Curently pool is PPS, after m.mining is implemented will be SMPPS (pool website) @ 09.23.11
-
+info_4: Operational merged Mining with the SMPPS payment system. Optionally can be mine without registering (pool website) - 7.56 Gh/s @ 10.10.11
 
 #i0c pools
 
@@ -340,14 +340,14 @@ info_1: Solidcoin pool, use mine_scc - 23.64 Ghash/s @ 08.28.11
 [mine4us]
 #http://solid.mine-for.us
 info_1: Solidcoin pool, use mine_scc - 2.51 Ghash/s @ 08.28.11
-
+info_2: Currently they are mining Namecoins until it is fixed the vulnerability of %51 of SolidCoin (pool website). Use the mine_nmc role - 1.98 GH/s @ 10.10.11
 
 #ixc pools
 
 [ixparking]
 #http://ixpool.bitparking.com/pool
 info_1: ixcoins pool, use mine_ixc - 4.99 Ghash/s @ 08.28.11
-
+info_2: Pool was closed on 30 September 2011 12:00 UTC (pool website) - 0 Ghash/s @ 10.10.11
 
 [digixc]
 #http://ix.digbtc.net

--- a/POOLS_INFO_ESP
+++ b/POOLS_INFO_ESP
@@ -291,7 +291,7 @@ info_1: Pagos automaticos sin necesidad de registrarse - 8.35 Ghash/s @ 08.23.11
 info_1: Mina namecoins (mine_nmc) - 47 Mhash/s @ 08.23.11
 info_2: La produccion se detiene hasta que la mineria unida comience a funcionar @ bloque 19200
 info_3: Sistema de pago actual es PPS, cuando la m. unida empiece sera SMPPS (pagina de mina) @ 09.23.11
-
+info_4: Funcionando bajo la mineria unida con sistema de pago SMPPS. Opcionalmente tambien se puede minar sin necesidad de registrarse (pagina de mina) - 7.56 Gh/s @ 10.10.11
 
 #Minas i0c
 
@@ -340,14 +340,14 @@ info_1: Mina solidcoin, usa el rol mine_scc - 23.64 Ghash/s @ 08.28.11
 [mine4us]
 #http://solid.mine-for.us
 info_1: Mina solidcoin, usa el rol mine_scc - 2.51 Ghash/s @ 08.28.11
-
+info_2: Actualmente estan minando Namecoins hasta que se arregle la vulnerabilidad del %51 de SolidCoin (pagina de mina). Usese el rol mine_nmc - 1.98 GH/s @ 10.10.11
 
 #Minas ixc
 
 [ixparking]
 #http://ixpool.bitparking.com/pool
 info_1: Mina IXcoins, usa el rol mine_ixc - 4.99 Ghash/s @ 08.28.11
-
+info_2: Esta mina cerro el 30 Septiembre 2011 12:00 UTC (pagina de mina) - 0 Ghash/s @ 10.10.11
 
 [digixc]
 #http://ix.digbtc.net

--- a/bh.cfg.default
+++ b/bh.cfg.default
@@ -26,6 +26,9 @@ backup_type = rejectrate
 # Minimum coin profitability
 min_coin_proff = 1.0
 
+# Indicates if the program would mine the coins more profitable or if only mine based on the number of shares of each pool.
+calculate_profit = True
+
 # Time limit after which we no longer display workers on the stats page
 user_drop_time = 60*60
 

--- a/bh.cfg.default_esp
+++ b/bh.cfg.default_esp
@@ -26,6 +26,9 @@ backup_type = rejectrate
 # Ganancia minima cuando se trabaja con varias monedas
 min_coin_proff = 1.0
 
+# Indica si el programa minara las monedas mas provechosas o si se mina unicamente en base a la cantidad de shares de cada pool.
+calculate_profit = True
+
 # Tiempo de muestra trabajadores parados en pagina de stats
 user_drop_time = 60*60
 

--- a/exchange.py
+++ b/exchange.py
@@ -6,6 +6,7 @@
 import re
 import eventlet
 from eventlet.green import threading, socket, urllib2
+from ConfigParser import NoOptionError
 
 # Global timeout for sockets in case something leaks
 socket.setdefaulttimeout(900)
@@ -14,9 +15,10 @@ class Exchange():
     "Pulls Exchange rates, updates them and calculates profitability"
     def __init__(self, bitHopper):
         self.bitHopper = bitHopper
-        
+        try: self.calculate_profit = bitHopper.config.getboolean('main', 'calculate_profit')
+        except NoOptionError: self.calculate_profit = True
         self.lock = threading.RLock()
-        eventlet.spawn_n(self.update_difficulty)
+        eventlet.spawn_n(self.update_profitability)
         self.rate = {'btc':1.0}
         self.profitability = {'btc':1.0}
     
@@ -24,38 +26,42 @@ class Exchange():
     def updater(self, coin, url_diff, reg_exp = None):
         # Generic method to update the exchange rate of a given currency
         self.bitHopper.log_msg('Updating Exchange Rate of ' + coin)
-        try:
-            #timeout = eventlet.timeout.Timeout(5, Exception(''))
-            useragent = {'User-Agent': self.bitHopper.config.get('main', 'work_user_agent')}
-            req = urllib2.Request(url_diff, headers = useragent)
-            response = urllib2.urlopen(req)
-            if reg_exp == None: 
-                output = response.read()
-            else:
-                diff_str = response.read()
-                output = re.search(reg_exp, diff_str)
-                output = output.group(1)
-            self.rate[coin] = float(output)
-            self.bitHopper.log_dbg('Retrieved Exchange rate for ' +str(coin) + ': ' + output)
-        except Exception, e:
-            self.bitHopper.log_dbg('Unable to update exchange rate for ' + coin + ': ' + str(e))
-            self.rate[coin] = 0.0
-        finally:
-            #timeout.cancel()
-            pass
+        if self.calculate_profit == True:
+            try:
+                #timeout = eventlet.timeout.Timeout(5, Exception(''))
+                useragent = {'User-Agent': self.bitHopper.config.get('main', 'work_user_agent')}
+                req = urllib2.Request(url_diff, headers = useragent)
+                response = urllib2.urlopen(req)
+                if reg_exp == None: 
+                    output = response.read()
+                else:
+                    diff_str = response.read()
+                    output = re.search(reg_exp, diff_str)
+                    output = output.group(1)
+                self.rate[coin] = float(output)
+                self.bitHopper.log_dbg('Retrieved Exchange rate for ' +str(coin) + ': ' + output)
+            except Exception, e:
+                self.bitHopper.log_dbg('Unable to update exchange rate for ' + coin + ': ' + str(e))
+                self.rate[coin] = 0.0
+            finally:
+                #timeout.cancel()
+                pass
+        else: self.rate[coin] = 1.0
 
     def calc_profit(self):
         with self.lock:
             btc_diff = self.bitHopper.difficulty.diff['btc']
             for coin in self.rate:
-                if coin not in self.bitHopper.difficulty.diff:
-                    continue
-                diff = self.bitHopper.difficulty.diff[coin]
-                self.profitability[coin] = (float(btc_diff)/diff*self.rate[coin])
+                if self.calculate_profit == True:
+                    if coin not in self.bitHopper.difficulty.diff:
+                        continue
+                    diff = self.bitHopper.difficulty.diff[coin]
+                    self.profitability[coin] = (float(btc_diff) / diff * self.rate[coin])
+                else: self.profitability[coin] = 1.0
 
-    def update_difficulty(self):
+    def update_profitability(self):
         while True:
-            "Tries to update difficulty from the internet"
+            "Tries to update profit from the internet"
             with self.lock:
                 
                 self.updater("ixc", 'http://ixchange.bitparking.com:8080/api/ticker', '\"average\":([0-9.]+)')

--- a/pools.cfg
+++ b/pools.cfg
@@ -439,9 +439,9 @@ url: http://www.bitchomp.info/
 name: ABCPool.co (PPS)
 mine_address: pool.ABCPool.co:8332
 api_address: http://www.abcpool.co/stats.php
-api_method: disable
-api_key: <span class="stat">([0-9.]+) GH/s</span>
-api_strip: ' '
+api_method: re_rate
+api_key: <span class="stat">([0-9]+).[0-9]+ GH/s</span>
+api_strip: ''
 url: http://www.abcpool.co/stats.php
 
 [p2pool]

--- a/pools.cfg
+++ b/pools.cfg
@@ -428,12 +428,12 @@ url: http://www.namebit.org/details?username=%(user)s
 [bitchomp]
 name: BitChomp.info (NMC)
 namecoin: Yep
-mine_address: bitchomp.info:9098
-api_address: http://bitchomp.info/ncp/index.php
+mine_address: bitchomp.info:8332
+api_address: http://www.bitchomp.info/api
 api_method:re
-api_key: round</td><td class="show">([ 0-9]+)</td>
-api_strip:' '
-url: http://www.bitchomp.info/ncp/user.php?address=%(user)s
+api_key: "shares": (\d+)
+api_strip:''
+url: http://www.bitchomp.info/
 
 [abc]
 name: ABCPool.co (PPS)

--- a/user.cfg.default
+++ b/user.cfg.default
@@ -394,12 +394,11 @@ user: nmcaddress
 pass: none
 
 [bitchomp]
-#http://www.bitchomp.info/ncp/register.php
+#http://www.bitchomp.info
 #CHANGE THIS (if you want)
 role: info
-user: your_username
-pass: your_password
-
+user: your_username.SomeWorkerName or BTC_Address.NMC_Address
+pass: Anything
 
 #i0c pools
 

--- a/user.cfg.default_esp
+++ b/user.cfg.default_esp
@@ -394,11 +394,11 @@ user: nmcaddress
 pass: none
 
 [bitchomp]
-#http://www.bitchomp.info/ncp/register.php
+#http://www.bitchomp.info/
 #CAMBIA A CONTINUACION (si quieres)
 role: info
-user: nombre_minero
-pass: contrasena_minero
+user: su_nombre_de_usuario.cualquier_cosa o direccion_BTC.direccion_NMC
+pass: cualquiera
 
 
 #Minas i0c


### PR DESCRIPTION
Was hard for me, but this time do not send one, not two, but three commits with what I was doing (all under public domain).
Certainly, I know that the parameter api_method of the BitChomp API settings should be json, but is that the shares can only be obtained using regular expressions.
