### PR TITLE
Simplifying a bit the life

### DIFF
--- a/api.py
+++ b/api.py
@@ -226,7 +226,7 @@ class API():
                 info = info.replace(strip_char,'')
             
         if info == None:
-            round_shares = int(self.bitHopper.difficulty.get_difficulty())
+            round_shares = int(self.bitHopper.difficulty.btc_difficulty)
         else:   
             round_shares = int(info)
                     

--- a/api.py
+++ b/api.py
@@ -17,7 +17,8 @@ class API():
         self.bitHopper = bitHopper
         self.api_lock = {}
         self.pool = self.bitHopper.pool
-        self.api_pull = ['mine', 'info', 'mine_c', 'mine_nmc', 'mine_ixc', 'mine_i0c',  'mine_scc', 'mine_charity', 'mine_lp',  'backup', 'backup_latehop']
+        self.api_pull = ['mine', 'info', 'mine_c', 'mine_charity', 'mine_lp',  'backup', 'backup_latehop']
+        self.api_pull.extend(['mine_' + coin for coin, diff in self.bitHopper.difficulty.diff.iteritems() if coin != 'btc'])
         self.api_disable_sec = 7200
         try:
             self.api_disable_sec = self.bitHopper.config.getint('main', 'api_disable_sec')
@@ -29,12 +30,6 @@ class API():
 
         #Actual Share Update      
         prev_shares = self.pool.servers[server]['shares']
-
-        diff_btc = self.bitHopper.difficulty.get_difficulty()
-        diff_nmc = self.bitHopper.difficulty.get_nmc_difficulty()
-        diff_scc = self.bitHopper.difficulty.get_scc_difficulty()
-        diff_i0c = self.bitHopper.difficulty.get_i0c_difficulty()
-        diff_ixc = self.bitHopper.difficulty.get_ixc_difficulty()
 
         #Mark it as unlagged
         self.pool.servers[server]['api_lag'] = False       
@@ -74,16 +69,10 @@ class API():
 
         #If the shares indicate we found a block tell LP
         coin_type = self.pool.servers[server]['coin']        
-        if coin_type == 'btc' and shares < prev_shares and shares < 0.10 * diff_btc:
-            self.bitHopper.lp.set_owner(server)
-        elif coin_type == 'nmc' and shares < prev_shares and shares < 0.10 * diff_nmc:
-            self.bitHopper.lp.set_owner(server)
-        elif coin_type == 'scc' and shares < prev_shares and shares < 0.10 * diff_scc:
-            self.bitHopper.lp.set_owner(server)
-        elif coin_type == 'ixc' and shares < prev_shares and shares < 0.10 * diff_ixc:
-            self.bitHopper.lp.set_owner(server)
-        elif coin_type == 'i0c' and shares < prev_shares and shares < 0.10 * diff_i0c:
-            self.bitHopper.lp.set_owner(server)
+        for title, attr_coin in self.bitHopper.altercoins.iteritems():
+            if coin_type == attr_coin['short_name'] and shares < prev_shares and shares < 0.10 * self.bitHopper.difficulty.__dict__[coin_type + '_difficulty']:
+                self.bitHopper.lp.set_owner(server)
+                break
 
         self.pool.servers[server]['shares'] = int(shares)
         self.pool.servers[server]['err_api_count'] = 0

--- a/bitHopper.py
+++ b/bitHopper.py
@@ -49,6 +49,12 @@ class BitHopper():
         """Initializes all of the submodules bitHopper uses"""
         self.options = options
         self.config = config        
+        altercoins = ConfigParser.ConfigParser()
+        altercoins.read(os.path.join(sys.path[0], "whatevercoin.cfg"))
+        self.altercoins = {}
+        for coin in altercoins.sections():
+            self.altercoins[coin] = dict(altercoins.items(coin))
+            self.altercoins[coin]['recent_difficulty'] = float(self.altercoins[coin]['recent_difficulty'])
         self.scheduler = None
         self.lp_callback = lp_callback.LP_Callback(self)
         self.difficulty = diff.Difficulty(self)  

--- a/data.py
+++ b/data.py
@@ -80,7 +80,7 @@ class Data():
                 self.speed.add_shares(1)
                 self.db.update_shares(server, 1, user, password)
                 self.pool.get_servers()[server]['user_shares'] += 1
-                self.pool.get_servers()[server]['expected_payout'] += 1.0/self.difficulty.get_difficulty() * 50.0
+                self.pool.get_servers()[server]['expected_payout'] += 1.0 / self.difficulty.btc_difficulty * 50.0
                 self.user_share_add(user, password, 1, server)
 
         except Exception, e:

--- a/database.py
+++ b/database.py
@@ -41,14 +41,14 @@ class Database():
 
     def sql_insert(self, server, shares=0, rejects=0, payout=0, user='', diff=None):
         if diff == None:
-            difficulty = self.bitHopper.difficulty.get_difficulty()
+            difficulty = self.bitHopper.difficulty.btc_difficulty
         else:
             difficulty = diff
         sql = 'INSERT INTO ' + server + ' VALUES ( ' + str(difficulty) + ',' + str(shares) + ',' + str(rejects) + ',' + str(payout) + ',\'' + user + '\')'
         return sql
 
     def sql_update_add(self, server, value, amount, user):
-        difficulty = self.bitHopper.difficulty.get_difficulty()
+        difficulty = self.bitHopper.difficulty.btc_difficulty
         sql = 'UPDATE ' + str(server) + ' SET ' + value + ' = ' + value + ' + ' + str(amount) + ' WHERE diff = ' + str(difficulty) + ' and user = \'' + user + "\'"
         return sql
 
@@ -67,7 +67,7 @@ class Database():
                 for server_name in self.pool.get_servers():
                     self.make_table(server_name)
 
-                difficulty = self.bitHopper.difficulty.get_difficulty()
+                difficulty = self.bitHopper.difficulty.btc_difficulty
                 for server in self.shares:
                     for user in self.shares[server]:
                         if self.shares[server][user] == 0:

--- a/diff.py
+++ b/diff.py
@@ -14,13 +14,11 @@ socket.setdefaulttimeout(900)
 class Difficulty():
     "Stores difficulties and automaticlaly updates them"
     def __init__(self, bitHopper):
+        self.diff = {}
+        for title, attr_coin in bitHopper.altercoins.iteritems():
+            self.__dict__[attr_coin['short_name'] + '_difficulty'] = self.diff[attr_coin['short_name']] = attr_coin['recent_difficulty']
+            #setattr(self, 'get_%s_difficulty' % attr_coin['short_name'], lambda: self.__dict__[attr_coin['short_name'] + '_difficulty'])
         self.bitHopper = bitHopper
-        self.btc_difficulty = 1755425.3203287
-        self.nmc_difficulty = 94037.96
-        self.ixc_difficulty = 16384
-        self.i0c_difficulty = 1372
-        self.scc_difficulty = 5354
-        self.gg_difficulty = 30
         cfg = ConfigParser.ConfigParser()
         cfg.read(["diffwebs.cfg"])
         self.diff_sites = []
@@ -28,22 +26,6 @@ class Difficulty():
              self.diff_sites.append(dict(cfg.items(site)))
         self.lock = threading.RLock()
         eventlet.spawn_n(self.update_difficulty)
-        self.diff = {'btc': self.btc_difficulty, 'nmc': self.nmc_difficulty, 'ixc': self.ixc_difficulty, 'i0c': self.i0c_difficulty, 'scc': self.scc_difficulty, 'gg': self.gg_difficulty}
-
-    def get_difficulty(self):
-        return self.btc_difficulty
-    
-    def get_nmc_difficulty(self):
-        return self.nmc_difficulty
-
-    def get_ixc_difficulty(self):
-        return self.ixc_difficulty
-    
-    def get_i0c_difficulty(self):
-        return self.i0c_difficulty
-    
-    def get_scc_difficulty(self):
-        return self.scc_difficulty
 
     def updater(self, coin, short_coin):
         # Generic method to update the difficulty of a given currency
@@ -77,10 +59,12 @@ class Difficulty():
         while True:
             "Tries to update difficulty from the internet"
             with self.lock:
-                
-                self.updater("Bitcoin", 'btc')
-                self.updater("Namecoin", 'nmc')
-                self.updater("SolidCoin", 'scc')
-                self.updater("IXcoin", 'ixc')
-                self.updater("I0coin", 'i0c')
+                output_diffs = ConfigParser.ConfigParser()
+                output_diffs.read("whatevercoin.cfg")   
+                for generic_title, attr_coin in self.bitHopper.altercoins.iteritems():
+                    self.updater(attr_coin['long_name'], attr_coin['short_name'])
+                    output_diffs.set(generic_title, 'recent_difficulty', self.diff[attr_coin['short_name']])
+                output = open("whatevercoin.cfg", 'wb')
+                output_diffs.write(output)
+                output.close()
             eventlet.sleep(60*10)

--- a/diffwebs.cfg
+++ b/diffwebs.cfg
@@ -91,10 +91,10 @@ url = http://blockexplorer.sytes.net/chain/I0coin?count=1
 get_method = regexp
 pattern = <td>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}</td><td>\d{1,}</td><td>[.0-9]+</td><td>([.0-9]+)</td>
 
-#Gold Geist
+#Geist Geld
 [allchains]
-coin = gg
-url = allchains.info/index.html
+coin = geg
+url = http://allchains.info/index.html
 get_method = regexp
 pattern = gg </td><td align='right'> [0-9]+ </td><td align='right'> [0-9]+ </td><td align='right'> [0-9]+ </td><td align='right'> [0-9]+ </td><td align='right'> [.0-9]+% </td><td align='right'> ([.0-9]+)
 

--- a/exchange.py
+++ b/exchange.py
@@ -63,12 +63,10 @@ class Exchange():
         while True:
             "Tries to update profit from the internet"
             with self.lock:
+                for generic_title, market in self.bitHopper.altercoins.iteritems():
+                    if market.has_key('site_exchange') and market.has_key('pattern_site_exchange'):
+                        self.updater(market['long_name'], market['site_exchange'], market['pattern_site_exchange'])
                 
-                self.updater("ixc", 'http://ixchange.bitparking.com:8080/api/ticker', '\"average\":([0-9.]+)')
-                self.updater("nmc", 'https://exchange.bitparking.com/main', "<th>Low:</th><td class=\"coin\">([0-9.]+)</td>")
-                self.updater("scc", 'https://btc-e.com/sc_exchanger',  "Highest Bid Price<p><b><span id='max_price'>([0-9.]+)")
-                self.updater("i0c", 'http://i0exchange.bitparking.com:8080/api/ticker', '\"average\":([0-9.]+)')
-                self.updater("gg", 'https://btc-e.com/exchange/gg_btc', "Highest Bid Price<p><b><span id='max_price'>([.0-9]+)")
                 self.calc_profit()
 
     

--- a/index.html
+++ b/index.html
@@ -77,14 +77,8 @@
 					return "N/A";
 				}
 
-				switch (srv['role'])
-				{
-					case 'mine_ixc': diff = payload['ixc_difficulty']; break;
-					case 'mine_i0c': diff = payload['i0c_difficulty']; break;
-					case 'mine_nmc': diff = payload['nmc_difficulty']; break;
-					case 'mine_scc': diff = payload['scc_difficulty']; break;
-					default: diff = payload['difficulty']; break;
-				}
+				diff = payload["diffs"][srv["role"].substring(5,8)];
+				if (diff == undefined) { diff = payload["diffs"]["btc"]; }
 
 				return numberWithCommas(shares)
 					+ "<br>"

--- a/lp.py
+++ b/lp.py
@@ -158,7 +158,7 @@ class LongPoll():
         self.bitHopper.log_dbg('received lp from: ' + server)
         self.bitHopper.log_trace('LP: ' + str(body))
         info = self.bitHopper.pool.servers[server]
-        if info['role'] in ['mine_nmc', 'disable', 'mine_ixc', 'mine_i0c', 'mine_scc', 'info']:
+        if info['role'] in ['disable', 'info'] + ['mine_' + coin for coin, diff in self.bitHopper.difficulty.iteritems() if coin != 'btc']:
             return
         if body == None:
             self.bitHopper.log_dbg('error in long poll from: ' + server)

--- a/plugins/lpworkbench/lpworkbench.html
+++ b/plugins/lpworkbench/lpworkbench.html
@@ -162,14 +162,8 @@
                                 return "N/A";
                         }
                         
-                        switch (srv['role'])
-                        {
-                                case 'mine_ixc': diff = payload['ixc_difficulty']; break;
-                                case 'mine_i0c': diff = payload['i0c_difficulty']; break;
-                                case 'mine_nmc': diff = payload['nmc_difficulty']; break;
-                                case 'mine_scc': diff = payload['scc_difficulty']; break;
-                                default: diff = payload['difficulty']; break;
-                        }
+                        diff = payload["diffs"][srv["role"].substring(5,8)];
+                        if (diff == undefined) { diff = payload["diffs"]["btc"]; }
                         
                         return shares
                                 + "<br>"
@@ -340,7 +334,7 @@
                     
                 function getEfficiency(payload, srv) {
                         var payout = srv["payout"]
-                        var expect = (parseFloat(srv["user_shares"])*50)/payload["difficulty"];
+                        var expect = (parseFloat(srv["user_shares"])*50) / payload["diffs"]["btc"];
                         expect  = parseFloat((parseFloat(payout)/expect) * 100).toFixed(1);
                         var pay_str = expect +  "%";
                         if (isNaN(expect)) {

--- a/plugins/lpworkbench/lpworkbench.py
+++ b/plugins/lpworkbench/lpworkbench.py
@@ -119,11 +119,7 @@ class lpWorkbenchDataSite():
         response = json.dumps({
             "current":self.bitHopper.pool.get_current(), 
             'mhash':self.bitHopper.speed.get_rate(), 
-            'difficulty':self.bitHopper.difficulty.get_difficulty(),
-            'ixc_difficulty':self.bitHopper.difficulty.get_ixc_difficulty(),
-            'i0c_difficulty':self.bitHopper.difficulty.get_i0c_difficulty(),
-            'nmc_difficulty':self.bitHopper.difficulty.get_nmc_difficulty(),
-            'scc_difficulty':self.bitHopper.difficulty.get_scc_difficulty(),
+            'diffs': self.bitHopper.difficulty.diff,
             'block':sorted_blocks,
             'accuracy':filterdAccuracy,
             'servers':servers})

--- a/pool_class.py
+++ b/pool_class.py
@@ -13,7 +13,7 @@ class Pool():
         self._parse(attribute_dict)
 
     def _parse(self, attribute_dict):
-        self['shares'] = int(self.bitHopper.difficulty.get_difficulty())
+        self['shares'] = int(self.bitHopper.difficulty.btc_difficulty)
         self['ghash'] = -1
         self['duration'] = -2
         self['duration_temporal'] = 0
@@ -49,7 +49,10 @@ class Pool():
         self['priority'] = int(attribute_dict.get('priority', 0))
 
         #Coin Handling
-        coin_roles = {'mine': 'btc', 'info': 'btc', 'backup': 'btc', 'backup_latehop': 'btc', 'mine_charity': 'btc', 'mine_c':'btc', 'mine_nmc': 'nmc', 'mine_ixc': 'ixc', 'mine_i0c': 'i0c', 'mine_scc': 'scc'}
+        coin_roles = {'mine': 'btc', 'info': 'btc', 'backup': 'btc', 'backup_latehop': 'btc', 'mine_charity': 'btc', 'mine_c':'btc'}
+        for title, coin in self.bitHopper.altercoins.iteritems():
+            if coin['short_name'] != 'btc':
+                coin_roles[coin['short_name']] = 'mine_' + coin['short_name']
         if 'coin' not in attribute_dict:
             try: coin_type = coin_roles[self['role']]
             except KeyError: coin_type = 'btc'
@@ -100,11 +103,9 @@ class Pool():
                 return self_proff < other_proff
 
     def btc_shares(self):
-        coin_diffs = {'btc': self.bitHopper.difficulty.get_difficulty(),
-        'nmc': self.bitHopper.difficulty.get_nmc_difficulty(),
-        'ixc': self.bitHopper.difficulty.get_ixc_difficulty(),
-        'i0c': self.bitHopper.difficulty.get_i0c_difficulty(),
-        'scc': self.bitHopper.difficulty.get_scc_difficulty()}
+        coin_diffs = {}
+        for title, attr_coin in self.bitHopper.altercoins.iteritems():
+            coin_diffs[attr_coin['short_name']] = self.bitHopper.difficulty.__dict__[attr_coin['short_name'] + '_difficulty']
         
         if self['coin'] in ['btc']:
             shares = self['shares']

--- a/scheduler.py
+++ b/scheduler.py
@@ -51,7 +51,7 @@ class Scheduler(object):
 
     def select_charity_server(self):
         server_name = None
-        most_shares = self.bitHopper.difficulty.get_difficulty() * 2
+        most_shares = self.bitHopper.difficulty.btc_difficulty * 2
         for server in self.bitHopper.pool.get_servers():
             info = self.bitHopper.pool.get_entry(server)
             if info['role'] != 'mine_charity':
@@ -117,7 +117,7 @@ class DefaultScheduler(Scheduler):
     def select_best_server(self,):
         #self.bitHopper.log_dbg('select_best_server', cat='scheduler-default')
         server_name = None
-        difficulty = self.bitHopper.difficulty.get_difficulty()
+        difficulty = self.bitHopper.difficulty.btc_difficulty
         min_shares = difficulty * self.difficultyThreshold
 
         #self.bitHopper.log_dbg('min-shares: ' + str(min_shares), cat='scheduler-default')  
@@ -143,7 +143,7 @@ class DefaultScheduler(Scheduler):
     def server_update(self,):
         current = self.bitHopper.pool.get_current()
         shares,info = self.server_to_btc_shares(current)
-        difficulty = self.bitHopper.difficulty.get_difficulty()
+        difficulty = self.bitHopper.difficulty.btc_difficulty
 
         if not self.server_is_valid(current):
             return True
@@ -183,7 +183,7 @@ class WaitPenaltyScheduler(Scheduler):
     def select_best_server(self,):
         #self.bitHopper.log_dbg('select_best_server', cat='scheduler-waitpenalty')
         server_name = None
-        difficulty = self.bitHopper.difficulty.get_difficulty()
+        difficulty = self.bitHopper.difficulty.btc_difficulty
         min_shares = difficulty * self.difficultyThreshold
 
         #self.bitHopper.log_dbg('min-shares: ' + str(min_shares), cat='scheduler-waitpenalty')  
@@ -208,7 +208,7 @@ class WaitPenaltyScheduler(Scheduler):
     def server_update(self,):
         current = self.bitHopper.pool.get_current()
         shares,info = self.server_to_btc_shares(current)
-        difficulty = self.bitHopper.difficulty.get_difficulty()
+        difficulty = self.bitHopper.difficulty.btc_difficulty
 
         if not self.server_is_valid(server):
             return True
@@ -263,7 +263,7 @@ class SimpleSliceScheduler(Scheduler):
 
     def select_best_server(self,):
         #self.bitHopper.log_dbg('select_best_server', cat='scheduler-default')
-        difficulty = self.bitHopper.difficulty.get_difficulty()
+        difficulty = self.bitHopper.difficulty.btc_difficulty
         min_shares = difficulty * self.difficultyThreshold
 
         valid_servers = []
@@ -315,7 +315,7 @@ class SimpleSliceScheduler(Scheduler):
             if current - self.sliceinfo[server] > 30:
                 return True
 
-        difficulty = self.bitHopper.difficulty.get_difficulty()
+        difficulty = self.bitHopper.difficulty.btc_difficulty
         min_shares = difficulty * self.difficultyThreshold
 
         shares = self.server_to_btc_shares(self.bitHopper.pool.get_current())[0]
@@ -381,7 +381,7 @@ class AltSliceScheduler(Scheduler):
             if 'init' not in info:
                 info['init'] = False
         if self.roundtimebias:
-            difficulty = self.bitHopper.difficulty.get_difficulty()
+            difficulty = self.bitHopper.difficulty.btc_difficulty
             one_ghash = 1000000 * 1000
             target_ghash = one_ghash * int(self.target_ghash) * (1+self.difficultyThreshold)
             self.bitHopper.log_msg(' - Target Round Time Bias GHash/s (derived): ' + str(float(target_ghash/one_ghash)), cat=self.name)
@@ -391,7 +391,7 @@ class AltSliceScheduler(Scheduler):
     def select_best_server(self,):
         self.bitHopper.log_trace('select_best_server', cat=self.name)
         server_name = None
-        difficulty = self.bitHopper.difficulty.get_difficulty()
+        difficulty = self.bitHopper.difficulty.btc_difficulty
         min_shares = difficulty * self.difficultyThreshold
 
         current_server = self.bitHopper.pool.get_current()
@@ -672,7 +672,7 @@ class AltSliceScheduler(Scheduler):
             return True
           
         # check to see if threshold exceeded
-        difficulty = self.bitHopper.difficulty.get_difficulty()
+        difficulty = self.bitHopper.difficulty.btc_difficulty
         min_shares = difficulty * self.difficultyThreshold
     
         if shares > min_shares:

--- a/scheduler.py
+++ b/scheduler.py
@@ -21,7 +21,8 @@ class Scheduler(object):
             self.difficultyThreshold = self.bitHopper.options.threshold
         else:
             self.difficultyThreshold = 0.435
-        self.valid_roles = ['mine', 'mine_nmc', 'mine_lp', 'mine_c', 'mine_ixc', 'mine_i0c', 'mine_scc', 'mine_charity', 'mine_force', 'mine_lp_force']
+        self.valid_roles = ['mine', 'mine_lp', 'mine_c', 'mine_charity', 'mine_force', 'mine_lp_force']
+        self.valid_roles.extend(['mine_' + coin for coin, diff in self.bitHopper.difficulty.diff.iteritems() if coin != 'btc'])
         hook_announce = plugins.Hook('plugins.lp.announce')
         hook_announce.register(self.mine_lp_force)
 

--- a/website.py
+++ b/website.py
@@ -70,7 +70,7 @@ class dynamicSite():
                             info = self.bitHopper.pool.get_entry(loopServer)
                             tempExpPayout = float(request.POST[v])
                             #info['expected_payout'] = float(request.POST[v])
-                            difficulty = self.bitHopper.difficulty.get_difficulty()
+                            difficulty = self.bitHopper.difficulty.btc_difficulty
                             tempUserShares = int(tempExpPayout * difficulty / 50)
                             #info['user_shares'] = int(info['expected_payout'] * difficulty / 50)
                             self.bitHopper.log_msg('Changing expected payout')
@@ -133,7 +133,7 @@ class dynamicSite():
                 try:
                     for server in self.bitHopper.pool.get_servers():
                         info = self.bitHopper.pool.get_entry(server)
-                        info['shares'] = self.bitHopper.difficulty.get_difficulty()
+                        info['shares'] = self.bitHopper.difficulty.btc_difficulty
                 except Exception,e:
                     self.bitHopper.log_msg('Incorrect http post resetshares: ' + str(e))
             if "reloadconfig" in v:

--- a/website.py
+++ b/website.py
@@ -217,11 +217,7 @@ class dataSite():
         response = json.dumps({
             "current":self.bitHopper.pool.get_current(), 
             'mhash':self.bitHopper.speed.get_rate(), 
-            'difficulty':self.bitHopper.difficulty.get_difficulty(),
-            'ixc_difficulty':self.bitHopper.difficulty.get_ixc_difficulty(),
-            'i0c_difficulty':self.bitHopper.difficulty.get_i0c_difficulty(),
-            'nmc_difficulty':self.bitHopper.difficulty.get_nmc_difficulty(),
-            'scc_difficulty':self.bitHopper.difficulty.get_scc_difficulty(),
+            'diffs': self.bitHopper.difficulty.diff,
             'sliceinfo':sliceinfo,
             'servers':servers,
             'user':self.bitHopper.data.get_users()})

--- a/whatevercoin.cfg
+++ b/whatevercoin.cfg
@@ -31,3 +31,10 @@ recent_difficulty = 54020.6623903
 site_exchange = https://btc-e.com/sc_exchanger
 pattern_site_exchange = Highest Bid Price<p><b><span id='max_price'>([0-9.]+)
 
+[coin5]
+long_name = Geist Geld
+short_name = geg
+recent_difficulty = 15.01306
+site_exchange = https://btc-e.com/exchange/gg_btc
+pattern_site_exchange = Highest Bid Price<p><b><span id='max_price'>([.0-9]+)
+

--- a/whatevercoin.cfg
+++ b/whatevercoin.cfg
@@ -1,0 +1,33 @@
+[coin0]
+long_name = Bitcoin
+short_name = btc
+recent_difficulty = 1468195.42722
+
+[coin1]
+long_name = Namecoin
+short_name = nmc
+recent_difficulty = 94035.9021742
+site_exchange = https://exchange.bitparking.com/main
+pattern_site_exchange = <th>Low:</th><td class=\"coin\">([0-9.]+)</td>
+
+[coin2]
+long_name = IXcoin
+short_name = ixc
+recent_difficulty = 293.76571529
+site_exchange = http://ixchange.bitparking.com:8080/api/ticker
+pattern_site_exchange = "average":([0-9.]+)
+
+[coin3]
+long_name = I0coin
+short_name = i0c
+recent_difficulty = 58.77063738
+site_exchange = http://i0exchange.bitparking.com:8080/api/ticker
+pattern_site_exchange = "average":([0-9.]+)
+
+[coin4]
+long_name = SolidCoin
+short_name = scc
+recent_difficulty = 54020.6623903
+site_exchange = https://btc-e.com/sc_exchanger
+pattern_site_exchange = Highest Bid Price<p><b><span id='max_price'>([0-9.]+)
+


### PR DESCRIPTION
From the creator of <a href=https://github.com/c00w/bitHopper/pull/469>"Fulfilling my word"</a> comes his most recent work, in which a programmer, his skill and his "ingenuity programmatic" confronts his toughest test of "bithopperian implementation" so far, but it will not be easy. Will he archieved, will succeed in their mission or all their work will be doomed to a <a href=http://en.wikipedia.org/wiki/Bsod>BSOD</a>/<a href=http://en.wikipedia.org/wiki/Kernel_Panic>Kernel Panic</a>? (obviously I have already done, so it would not do this pool request)
<sub>Coming soon in the near-source repository (ie here). No rights reserved 2011 (which means that this work is under </sub>public domain<sub>).</sub>

<hr>

Outside joke say that I was not so easy to make that the bitHopper be more "friendly" with alternative coins since I was a long time thinking about how to do this, moreover, had also considered doing this with <a href=http://www.simple-is-better.org/template/pyratemp.html#overview>Pyratemp</a> (a simple, easy to use, small, fast, modular, well documented and pythonic template-engine) transformng them files that I modified in <a href=https://github.com/Swicher/bitHopper/commit/60b5fa94c01815f327a7e81eaafb6a9eed8fb0ce>this commit</a> into templates. But anyway I must say that these changes were quite well because that adding a new coin in whatevercoin.cfg (and then start the program) the Bithopper automatically make the "mine_coin" role, so just have to modify one or two files instead of 11. Still not everything is "rosy" because in diff.py module I could not achieve to create dynamic methods correctly to show the difficulty of a coin ("get_coin_difficulty ()", anyway I leave commented the line responsible of this in case anyone wants to try this detail).
