### PR TITLE
"Fix" for MTRed not pulling hashrate and shares info.

### DIFF
--- a/pools.cfg
+++ b/pools.cfg
@@ -74,10 +74,13 @@ url: https://polmine.pl/?action=dashboardstat
 coin:btc
 name: MtRed.com (MergeM-PPS)
 mine_address: mtred.com:8337
-api_address: https://mtred.com/api/user/key/%(mtred_user_apikey)s
+#api_address: https://mtred.com/api/user/key/%(mtred_user_apikey)s
+api_address: https://mtred.com/api/stats
 api_method: json
-api_key: server,roundshares
-api_key_ghashrate: server,hashrate
+#api_key: server,roundshares
+#api_key_ghashrate: server,hashrate
+api_key: roundshares
+api_key_ghashrate: hashrate
 url: https://mtred.com/user/profile.html
 
 [rfc]


### PR DESCRIPTION
MTRed was not properly reporting stats in the 2.5.5. download
