### PR TITLE
make penalty for backup role works as descried in user.cfg

### DIFF
--- a/pool_class.py
+++ b/pool_class.py
@@ -77,9 +77,9 @@ class Pool():
         #backup sorts by reject rate
         if self['role'] in ['backup']:
             rr_self = float(self['rejects'])/(self['user_shares']+1)
-            rr_self += self.get('penalty', 0.0)
+            rr_self += float(self.get('penalty', 0.0)) / 100
             rr_other = float(other['rejects'])/(other['user_shares']+1)
-            rr_other += other.get('penalty', 0.0)
+            rr_other += float(other.get('penalty', 0.0)) / 100
             return rr_self < rr_other
 
         #backup latehop sorts purely by shares


### PR DESCRIPTION
This patch fix 2 issues about usage of penalty value for backup servers:
1. it is not treated as float value;
2. its unit is not percent.
