### PR TITLE
fix for github issue #639

### DIFF
--- a/Workers.py
+++ b/Workers.py
@@ -15,6 +15,8 @@ class Workers():
         self.workers = {}
         self.lock = threading.Lock()
         self.parser = ConfigParser.RawConfigParser()
+        # Override optionxform to avoid downcasing option names (usernames)
+        self.parser.optionxform = lambda x: x
         self.queue = Queue.Queue(maxsize=-1)
         
         thread = threading.Thread(target=self.poll_thread)


### PR DESCRIPTION
Don't downcase option names (usernames)!

---

This should fix the issue I reported. Please close it, once this is merged and verified.

I don't really like how worker.cfg is being rewritten by OptionParser, but I'm not going to attempt to address that at this time.
